### PR TITLE
Fix header layout and popup styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,10 +41,10 @@
   </div>
 
   <header>
+    <h1>ÖPPNA MÖLLAN - 2025</h1>
     <a class="logo-link" href="https://www.facebook.com/events/569497915741012?locale=sv_SE" rel="noopener">
       <img src="Vit_emblem.png" alt="Öppna Möllan logotyp" />
     </a>
-    <h1>ÖPPNA MÖLLAN - 2025</h1>
     <select id="activityFilter" aria-label="Filtrera efter aktivitet">
       <option value="Alla">Alla aktiviteter</option>
     </select>

--- a/main.js
+++ b/main.js
@@ -32,6 +32,8 @@ map.addControl(
   })
 );
 
+let activitySelect;
+
 class ActivityControl {
   onAdd(map) {
     this._map = map;
@@ -57,7 +59,6 @@ let userLngLat;
 const removeRouteBtn = document.getElementById('removeRouteBtn');
 const addressMarkers = [];
 const activitySet = new Set();
-let activitySelect;
 
 if (navigator.geolocation) {
   navigator.geolocation.watchPosition(

--- a/style.css
+++ b/style.css
@@ -43,7 +43,7 @@ header {
 
 .logo-link img {
   height: 60px;
-  margin-right: 1rem;
+  margin-left: 1rem;
 }
 
 header h1 {
@@ -234,9 +234,12 @@ header h1 {
   }
 
   .maplibregl-ctrl-group button,
-  .maplibregl-popup-content-wrapper,
-  .maplibregl-popup-tip {
+  .maplibregl-popup-content-wrapper {
     background-color: #232323;
+    color: #f4f4f4;
+  }
+
+  .maplibregl-popup-content {
     color: #f4f4f4;
   }
 


### PR DESCRIPTION
## Summary
- move title before logo in header
- adjust logo spacing
- update popup styles for dark mode and remove tip background

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684bf6ee160083339ff3cddf26f9334d