### PR TITLE
Fix dark mode popup arrow

### DIFF
--- a/style.css
+++ b/style.css
@@ -178,6 +178,12 @@ header h1 {
 
   .maplibregl-popup-tip {
     border-top-color: #232323;
+    background: none;
+  }
+
+  .maplibregl-popup-tip path {
+    fill: #232323;
+    stroke: none;
   }
   
 }


### PR DESCRIPTION
## Summary
- ensure popup arrow tip in dark mode uses the same color as the popup
- remove unwanted background behind the arrow

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684c0ff7581c8333b69df977e011d087